### PR TITLE
Fam dev

### DIFF
--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -265,6 +265,8 @@ static int pp_alloc_gpu_buf(struct pingpong_context *ctx, void **pbuf, size_t si
 		rc = 1;
 		goto err;
 	}
+    pbuf[0] = buf;
+
 err:
         return rc;
 }

--- a/src/send_bw.c
+++ b/src/send_bw.c
@@ -465,10 +465,12 @@ int main(int argc, char *argv[])
 			}
 		}
 
-                if (user_param.duplex && ctx.gpu_ext_buf) {
-                        fprintf(stderr,"Duplex test with extra GPU is not supported\n");
-                        return FAILURE;
-                }
+#ifdef HAVE_CUDA
+        if (user_param.duplex && ctx.gpu_ext_buf) {
+            fprintf(stderr,"Duplex test with extra GPU is not supported\n");
+            return FAILURE;
+        }
+#endif
 
 		if (ctx_hand_shake(&user_comm,&my_dest[0],&rem_dest[0])) {
 			fprintf(stderr,"Failed to exchange data between server and clients\n");


### PR DESCRIPTION
Fixed two bugs:
1. Compile error due to accessing ctx.gpu_ext_buf when compiling without CUDA.
2. Runtime error from pp_alloc_gpu_buf does not assign pbuf.